### PR TITLE
Added Prometheus PushGateway support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,9 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftPrometheus",
+    platforms: [
+        .iOS(.v13)
+    ],
     products: [
         .library(
             name: "SwiftPrometheus",

--- a/Sources/Prometheus/RepeatingTimer/RepeatingTimer.swift
+++ b/Sources/Prometheus/RepeatingTimer/RepeatingTimer.swift
@@ -1,0 +1,65 @@
+//
+//  File.swift
+//  
+//
+//  Created by Svilen Kirov on 5.07.22.
+//
+
+import Foundation
+
+/// RepeatingTimer mimics the API of DispatchSourceTimer but in a way that prevents
+/// crashes that occur from calling resume multiple times on a timer that is
+/// already resumed (noted by https://github.com/SiftScience/sift-ios/issues/52
+class RepeatingTimer {
+
+    let timeInterval: TimeInterval
+    
+    init(timeInterval: TimeInterval) {
+        self.timeInterval = timeInterval
+    }
+    
+    private lazy var timer: DispatchSourceTimer = {
+        let t = DispatchSource.makeTimerSource()
+        t.schedule(deadline: .now() + self.timeInterval, repeating: self.timeInterval)
+        t.setEventHandler(handler: { [weak self] in
+            self?.eventHandler?()
+        })
+        return t
+    }()
+
+    var eventHandler: (() -> Void)?
+
+    private enum State {
+        case suspended
+        case resumed
+    }
+
+    private var state: State = .suspended
+
+    deinit {
+        timer.setEventHandler {}
+        timer.cancel()
+        /*
+         If the timer is suspended, calling cancel without resuming
+         triggers a crash. This is documented here https://forums.developer.apple.com/thread/15902
+         */
+        resume()
+        eventHandler = nil
+    }
+
+    func resume() {
+        if state == .resumed {
+            return
+        }
+        state = .resumed
+        timer.resume()
+    }
+
+    func suspend() {
+        if state == .suspended {
+            return
+        }
+        state = .suspended
+        timer.suspend()
+    }
+}


### PR DESCRIPTION
Added support for the prometheus pushgateway.

### Checklist
- [x] The provided tests still run.
- [ ] I've created new tests where needed.
- [ ] I've updated the documentation if necessary.

### Motivation and Context

I needed a swift library, which would allow me to upload metrics to the pushgateway. I developed this solution and decided to suggest it as an improvement to the SwiftPrometheus library, as mentioned in #47. 

### Description

I did not change any of the existing functionalities, rather I added new ones. I added a repeating timer class, which allows for a process to be repeatedly triggered in the background. In addition to that I added two public functions to the Prometheus client, one for setting up the repeated pushes and one for tearing them down. There are two additional private helper functions, which should make the code easier to follow through.

I ran the available tests locally and also experimented with the framework in a personal project.

Once I receive confirmation that such a change is something that is welcome to this project, I will be more than happy to add additional tests and documentation. 

There is a lot of code and I am open for improvements/ suggestions. I would be more than happy to contribute to this project!
