### PR TITLE
Remove unused weak references

### DIFF
--- a/Sources/Prometheus/MetricTypes/Counter.swift
+++ b/Sources/Prometheus/MetricTypes/Counter.swift
@@ -3,10 +3,7 @@ import NIOConcurrencyHelpers
 /// Prometheus Counter metric
 ///
 /// See: https://prometheus.io/docs/concepts/metric_types/#counter
-public class PromCounter<NumType: Numeric>: PromMetric, PrometheusHandled {
-    /// Prometheus instance that created this Counter
-    internal weak var prometheus: PrometheusClient?
-    
+public class PromCounter<NumType: Numeric>: PromMetric {
     /// Name of the Counter, required
     public let name: String
     /// Help text of the Counter, optional
@@ -34,12 +31,11 @@ public class PromCounter<NumType: Numeric>: PromMetric, PrometheusHandled {
     ///     - help: Help text of the Counter
     ///     - initialValue: Initial value to set the counter to
     ///     - p: Prometheus instance that created this counter
-    internal init(_ name: String, _ help: String? = nil, _ initialValue: NumType = 0, _ p: PrometheusClient) {
+    internal init(_ name: String, _ help: String? = nil, _ initialValue: NumType = 0) {
         self.name = name
         self.help = help
         self.initialValue = initialValue
         self.value = initialValue
-        self.prometheus = p
         self.lock = Lock()
     }
     

--- a/Sources/Prometheus/MetricTypes/Gauge.swift
+++ b/Sources/Prometheus/MetricTypes/Gauge.swift
@@ -5,10 +5,7 @@ import NIOConcurrencyHelpers
 /// Prometheus Gauge metric
 ///
 /// See https://prometheus.io/docs/concepts/metric_types/#gauge
-public class PromGauge<NumType: DoubleRepresentable>: PromMetric, PrometheusHandled {
-    /// Prometheus instance that created this Gauge
-    internal weak var prometheus: PrometheusClient?
-    
+public class PromGauge<NumType: DoubleRepresentable>: PromMetric {
     /// Name of the Gauge, required
     public let name: String
     /// Help text of the Gauge, optional
@@ -37,12 +34,11 @@ public class PromGauge<NumType: DoubleRepresentable>: PromMetric, PrometheusHand
     ///     - initialValue: Initial value to set the Gauge to
     ///     - p: Prometheus instance that created this Gauge
     ///
-    internal init(_ name: String, _ help: String? = nil, _ initialValue: NumType = 0, _ p: PrometheusClient) {
+    internal init(_ name: String, _ help: String? = nil, _ initialValue: NumType = 0) {
         self.name = name
         self.help = help
         self.initialValue = initialValue
         self.value = initialValue
-        self.prometheus = p
         self.lock = Lock()
     }
     

--- a/Sources/Prometheus/MetricTypes/Histogram.swift
+++ b/Sources/Prometheus/MetricTypes/Histogram.swift
@@ -66,10 +66,7 @@ public struct Buckets: ExpressibleByArrayLiteral {
 /// Prometheus Histogram metric
 ///
 /// See https://prometheus.io/docs/concepts/metric_types/#Histogram
-public class PromHistogram<NumType: DoubleRepresentable>: PromMetric, PrometheusHandled {
-    /// Prometheus instance that created this Histogram
-    internal weak var prometheus: PrometheusClient?
-
+public class PromHistogram<NumType: DoubleRepresentable>: PromMetric {
     /// Name of this Histogram, required
     public let name: String
     /// Help text of this Histogram, optional
@@ -100,20 +97,18 @@ public class PromHistogram<NumType: DoubleRepresentable>: PromMetric, Prometheus
     ///     - help: Help text of the Histogram
     ///     - buckets: Buckets to use for the Histogram
     ///     - p: Prometheus instance creating this Histogram
-    internal init(_ name: String, _ help: String? = nil, _ buckets: Buckets = .defaultBuckets, _ p: PrometheusClient) {
+    internal init(_ name: String, _ help: String? = nil, _ buckets: Buckets = .defaultBuckets) {
         self.name = name
         self.help = help
 
-        self.prometheus = p
-
-        self.sum = .init("\(self.name)_sum", nil, 0, p)
+        self.sum = .init("\(self.name)_sum", nil, 0)
 
         self.upperBounds = buckets.buckets
 
         self.lock = Lock()
 
         buckets.buckets.forEach { _ in
-            self.buckets.append(.init("\(name)_bucket", nil, 0, p))
+            self.buckets.append(.init("\(name)_bucket", nil, 0))
         }
     }
 
@@ -239,8 +234,7 @@ public class PromHistogram<NumType: DoubleRepresentable>: PromMetric, Prometheus
                                  """)
                     return histogram
                 }
-                guard let prometheus = prometheus else { fatalError("Lingering Histogram") }
-                let newHistogram = PromHistogram(self.name, self.help, Buckets(self.upperBounds), prometheus)
+                let newHistogram = PromHistogram(self.name, self.help, Buckets(self.upperBounds))
                 self.subHistograms[labels] = newHistogram
                 return newHistogram
             }

--- a/Sources/Prometheus/MetricTypes/PromMetric.swift
+++ b/Sources/Prometheus/MetricTypes/PromMetric.swift
@@ -44,9 +44,3 @@ extension PromMetric {
         buffer.writeString(collect())
     }
 }
-
-/// Adding a prometheus instance to all metrics
-internal protocol PrometheusHandled {
-    /// Prometheus client handling this metric
-    var prometheus: PrometheusClient? { get }
-}

--- a/Sources/Prometheus/MetricTypes/Summary.swift
+++ b/Sources/Prometheus/MetricTypes/Summary.swift
@@ -6,10 +6,7 @@ import Dispatch
 /// Prometheus Summary metric
 ///
 /// See https://prometheus.io/docs/concepts/metric_types/#summary
-public class PromSummary<NumType: DoubleRepresentable>: PromMetric, PrometheusHandled {
-    /// Prometheus instance that created this Summary
-    internal weak var prometheus: PrometheusClient?
-    
+public class PromSummary<NumType: DoubleRepresentable>: PromMetric {
     /// Name of this Summary, required
     public let name: String
     /// Help text of this Summary, optional
@@ -49,17 +46,15 @@ public class PromSummary<NumType: DoubleRepresentable>: PromMetric, PrometheusHa
     ///     - capacity: Number of values to keep for calculating quantiles
     ///     - quantiles: Quantiles to use for the Summary
     ///     - p: Prometheus instance creating this Summary
-    internal init(_ name: String, _ help: String? = nil, _ capacity: Int = Prometheus.defaultSummaryCapacity, _ quantiles: [Double] = Prometheus.defaultQuantiles, _ p: PrometheusClient) {
+    internal init(_ name: String, _ help: String? = nil, _ capacity: Int = Prometheus.defaultSummaryCapacity, _ quantiles: [Double] = Prometheus.defaultQuantiles) {
         self.name = name
         self.help = help
         
-        self.prometheus = p
-        
         self.displayUnit = nil
         
-        self.sum = .init("\(self.name)_sum", nil, 0, p)
+        self.sum = .init("\(self.name)_sum", nil, 0)
         
-        self.count = .init("\(self.name)_count", nil, 0, p)
+        self.count = .init("\(self.name)_count", nil, 0)
         
         self.values = CircularBuffer(initialCapacity: capacity)
 
@@ -197,10 +192,7 @@ public class PromSummary<NumType: DoubleRepresentable>: PromMetric, PrometheusHa
                                  """)
                     return summary
                 }
-                guard let prometheus = prometheus else {
-                    fatalError("Lingering Summary")
-                }
-                let newSummary = PromSummary(self.name, self.help, self.capacity, self.quantiles, prometheus)
+                let newSummary = PromSummary(self.name, self.help, self.capacity, self.quantiles)
                 self.subSummaries[labels] = newSummary
                 return newSummary
             }

--- a/Sources/Prometheus/Prometheus.swift
+++ b/Sources/Prometheus/Prometheus.swift
@@ -138,7 +138,7 @@ public class PrometheusClient {
                 return cachedCounter
             }
 
-            let counter = PromCounter<T>(name, helpText, initialValue, self)
+            let counter = PromCounter<T>(name, helpText, initialValue)
             let oldInstrument = self.metrics.updateValue(counter, forKey: name)
             precondition(oldInstrument == nil, "Label \(oldInstrument!.name) is already associated with a \(oldInstrument!._type).")
             return counter
@@ -167,7 +167,7 @@ public class PrometheusClient {
                 return cachedGauge
             }
 
-            let gauge = PromGauge<T>(name, helpText, initialValue, self)
+            let gauge = PromGauge<T>(name, helpText, initialValue)
             let oldInstrument = self.metrics.updateValue(gauge, forKey: name)
             precondition(oldInstrument == nil, "Label \(oldInstrument!.name) is already associated with a \(oldInstrument!._type).")
             return gauge
@@ -196,7 +196,7 @@ public class PrometheusClient {
                 return cachedHistogram
             }
 
-            let histogram = PromHistogram<T>(name, helpText, buckets, self)
+            let histogram = PromHistogram<T>(name, helpText, buckets)
             let oldInstrument = self.metrics.updateValue(histogram, forKey: name)
             precondition(oldInstrument == nil, "Label \(oldInstrument!.name) is already associated with a \(oldInstrument!._type).")
             return histogram
@@ -226,7 +226,7 @@ public class PrometheusClient {
             if let cachedSummary: PromSummary<T> = self._getMetricInstance(with: name, andType: .summary) {
                 return cachedSummary
             }
-            let summary = PromSummary<T>(name, helpText, capacity, quantiles, self)
+            let summary = PromSummary<T>(name, helpText, capacity, quantiles)
             let oldInstrument = self.metrics.updateValue(summary, forKey: name)
             precondition(oldInstrument == nil, "Label \(oldInstrument!.name) is already associated with a \(oldInstrument!._type).")
             return summary


### PR DESCRIPTION
Remove unused `weak prometheusClient` references.

### Checklist
- [x] The provided tests still run.
- [x] I've created new tests where needed.
- [x] I've updated the documentation if necessary.

### Motivation and Context

Weak references are a performance bottleneck. Since the `PrometheusHandled` protocol is internal and not used at all, we can remove it and with this remove the weak references to the `PrometheusClient`. Less, but faster code.

### Description

- Remove `PrometheusHandled` protocol
- Remove `weak prometheusClient` references in the metrics.
