### PR TITLE
Fix Histogram Concurrency Issue

### DIFF
--- a/Sources/Prometheus/MetricTypes/Histogram.swift
+++ b/Sources/Prometheus/MetricTypes/Histogram.swift
@@ -221,7 +221,7 @@ public class PromHistogram<NumType: DoubleRepresentable>: PromMetric {
             return histogram
         } else {
             return lock.withLock {
-                if let histogram = subHistograms[labels] {
+                if let histogram = self.subHistograms[labels] {
                     precondition(histogram.name == self.name,
                                  """
                                  Somehow got 2 subHistograms with the same data type  / labels 


### PR DESCRIPTION
Issue:
In Histogram, some values were being dropped when the histogram is accessed concurrently by multiple threads.

Fix:
In getOrCreateHistogram, the code was copying the dictionary into a local variable, and checking it for the label without a lock. If not there, it would take the lock again to add it. But in line 224, after taking the lock again, it was rechecking the local variable, which of course would not have changed in the meantime. But the original dictionary could have changed, and that's the one we should check the second time.

Improved the concurrency test, as it was missing the bug by only checking the total count and sum without labels.

