### PR TITLE
Fix behaviour for all metric types when only calls with labels are made

### DIFF
--- a/Tests/SwiftPrometheusTests/GaugeTests.swift
+++ b/Tests/SwiftPrometheusTests/GaugeTests.swift
@@ -80,4 +80,22 @@ final class GaugeTests: XCTestCase {
         my_gauge{myValue="labels"} 20
         """)
     }
+
+    func testGaugeDoesNotReportWithNoLabelUsed() {
+        let gauge = prom.createGauge(forType: Int.self, named: "my_gauge")
+        gauge.inc(1, [("a", "b")])
+
+        XCTAssertEqual(gauge.collect(), """
+        # TYPE my_gauge gauge
+        my_gauge{a="b"} 1
+        """)
+
+        gauge.inc()
+
+        XCTAssertEqual(gauge.collect(), """
+        # TYPE my_gauge gauge
+        my_gauge 1
+        my_gauge{a="b"} 1
+        """)
+    }
 }

--- a/Tests/SwiftPrometheusTests/SanitizerTests.swift
+++ b/Tests/SwiftPrometheusTests/SanitizerTests.swift
@@ -61,7 +61,6 @@ final class SanitizerTests: XCTestCase {
         prom.collect(into: promise)
         XCTAssertEqual(try! promise.futureResult.wait(), """
         # TYPE dimensions_total counter
-        dimensions_total 0
         dimensions_total{invalid_service_dimension="something"} 1\n
         """)
     }

--- a/Tests/SwiftPrometheusTests/SwiftPrometheusTests.swift
+++ b/Tests/SwiftPrometheusTests/SwiftPrometheusTests.swift
@@ -48,4 +48,23 @@ final class SwiftPrometheusTests: XCTestCase {
             XCTAssertEqual(metricsString, "# HELP my_counter Counter for testing\n# TYPE my_counter counter\nmy_counter 30\nmy_counter{myValue=\"labels\"} 30\n")
         }
     }
+
+    func testCounterDoesNotReportWithNoLabelUsed() {
+        let counter = prom.createCounter(forType: Int.self, named: "my_counter")
+        counter.inc(1, [("a", "b")])
+
+        XCTAssertEqual(counter.collect(), """
+        # TYPE my_counter counter
+        my_counter{a="b"} 1
+        """)
+
+        counter.inc()
+
+        XCTAssertEqual(counter.collect(), """
+        # TYPE my_counter counter
+        my_counter 1
+        my_counter{a="b"} 1
+        """)
+    }
+
 }


### PR DESCRIPTION
Fixes #80 #77 

### Checklist
- [x] The provided tests still run.
- [x] I've created new tests where needed.
- [x] I've updated the documentation if necessary.

Fixes an internal inconsistency where recording to a summary or histogram with labels would overflow into their main (no labels) versions too. (#77)

Also removes "empty" reports of metrics (#80)
