### PR TITLE
fix: use lock for subsummary to get its values

### DIFF
--- a/Sources/Prometheus/MetricTypes/Summary.swift
+++ b/Sources/Prometheus/MetricTypes/Summary.swift
@@ -92,7 +92,7 @@ public class PromSummary<NumType: DoubleRepresentable>: PromMetric {
         output.append("\(self.name)_sum \(format(self.sum.get().doubleValue))")
 
         subSummaries.forEach { labels, subSum in
-            let subSumValues = lock.withLock { subSum.values }
+            let subSumValues = subSum.lock.withLock { subSum.values }
             calculateQuantiles(quantiles: self.quantiles, values: subSumValues.map { $0.doubleValue }).sorted { $0.key < $1.key }.forEach { (arg) in
                 let (q, v) = arg
                 let labelsString = encodeLabels(EncodableSummaryLabels(labels: labels, quantile: "\(q)"))


### PR DESCRIPTION
There is a race condition listed in https://github.com/swift-server-community/SwiftPrometheus/issues/79
### Checklist
- [x] The provided tests still run.
- [-] I've created new tests where needed.
- [-] I've updated the documentation if necessary.

### Motivation and Context
That solves race-condition and corresponding crash from https://github.com/swift-server-community/SwiftPrometheus/issues/79
