### PR TITLE
Add package index config file, so docs are generated

### DIFF
--- a/.spi.yaml
+++ b/.spi.yaml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [Prometheus]


### PR DESCRIPTION
Add configuration for swift package index so the docs for the package are generated there.
Then we link to that rather than to the 404-ed mrlotu docs page 

resolves https://github.com/swift-server-community/SwiftPrometheus/issues/84