### PR TITLE
Remove FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: [MrLotU]


### PR DESCRIPTION
Jari (the original maintainer) has left the project. This patch removes the GitHub sponsor option that sends money his way.